### PR TITLE
Adding support to `Date` and `Sys.args()`

### DIFF
--- a/src/Date.cross.hx
+++ b/src/Date.cross.hx
@@ -1,0 +1,101 @@
+package;
+
+class Date {
+	private var timestamp:Float;
+
+	public function new(year:Int, month:Int, day:Int, hour:Int, minute:Int, second:Int) {
+		var dict = untyped __gdscript__("{
+			'year': {0},
+			'month': {1},
+			'day': {2},
+			'hour': {3},
+			'minute': {4},
+			'second': {5}
+		}", year, month
+			+ 1, day, hour, minute, second);
+		timestamp = untyped __gdscript__("Time.get_unix_time_from_datetime_dict({0})", dict);
+	}
+
+	public static function now():Date {
+		var d = new Date(1970, 0, 1, 0, 0, 0);
+		d.timestamp = untyped __gdscript__("Time.get_unix_time_from_system()");
+		return d;
+	}
+
+	public static function fromTime(t:Float):Date {
+		var d = new Date(1970, 0, 1, 0, 0, 0);
+		d.timestamp = t / 1000.0;
+		return d;
+	}
+
+	public static function fromString(s:String):Date {
+		var parts = s.split(" ");
+		var dateParts = parts[0].split("-");
+		var year = Std.parseInt(dateParts[0]);
+		var month = Std.parseInt(dateParts[1]) - 1;
+		var day = Std.parseInt(dateParts[2]);
+
+		var hour = 0;
+		var minute = 0;
+		var second = 0;
+
+		if (parts.length > 1) {
+			var timeParts = parts[1].split(":");
+			hour = Std.parseInt(timeParts[0]);
+			minute = Std.parseInt(timeParts[1]);
+			if (timeParts.length > 2) {
+				second = Std.parseInt(timeParts[2]);
+			}
+		}
+
+		return new Date(year, month, day, hour, minute, second);
+	}
+
+	public function getTime():Float {
+		return timestamp * 1000.0;
+	}
+
+	private function getDateDict():Dynamic {
+		return untyped __gdscript__("Time.get_datetime_dict_from_unix_time({0})", timestamp);
+	}
+
+	public function getFullYear():Int {
+		return untyped getDateDict().year;
+	}
+
+	public function getMonth():Int {
+		return untyped getDateDict().month - 1;
+	}
+
+	public function getDate():Int {
+		return untyped getDateDict().day;
+	}
+
+	public function getHours():Int {
+		return untyped getDateDict().hour;
+	}
+
+	public function getMinutes():Int {
+		return untyped getDateDict().minute;
+	}
+
+	public function getSeconds():Int {
+		return untyped getDateDict().second;
+	}
+
+	public function getDay():Int {
+		return untyped getDateDict().weekday;
+	}
+
+	public function toString():String {
+		var dict = getDateDict();
+		var year = untyped dict.year;
+		var month = untyped dict.month;
+		var day = untyped dict.day;
+		var hour = untyped dict.hour;
+		var minute = untyped dict.minute;
+		var second = untyped dict.second;
+
+		return untyped __gdscript__('"%04d-%02d-%02d %02d:%02d:%02d" % [{0}, {1}, {2}, {3}, {4}, {5}]', year, month, day, hour, minute, second);
+	}
+}

--- a/src/Sys.cross.hx
+++ b/src/Sys.cross.hx
@@ -2,47 +2,47 @@ package;
 
 @:require(sys)
 extern class Sys {
-	@:runtime public inline static function print(v: Dynamic): Void {
+	@:runtime public inline static function print(v:Dynamic):Void {
 		untyped __gdscript__("print(str({0}))", v);
 	}
 
-	@:runtime public inline static function println(v: Dynamic): Void {
+	@:runtime public inline static function println(v:Dynamic):Void {
 		untyped __gdscript__("print(str({0}) + \"\n\")", v);
 	}
 
-	@:runtime public inline static function args(): Array<String> {
-		return [];
+	@:runtime public inline static function args():Array<String> {
+		return untyped __gdscript__("OS.get_cmdline_args()"); // [];
 	}
 
-	@:runtime public inline static function getEnv(s: String): String {
+	@:runtime public inline static function getEnv(s:String):String {
 		return untyped __gdscript__("OS.get_environment({0})", s);
 	}
 
-	@:runtime public inline static function putEnv(s: String, v: Null<String>): Void {
+	@:runtime public inline static function putEnv(s:String, v:Null<String>):Void {
 		return untyped __gdscript__("OS.set_environment({0}, {1})", s, v == null ? "" : v);
 	}
 
-	@:runtime public inline static function environment(): Map<String, String> {
+	@:runtime public inline static function environment():Map<String, String> {
 		throw "Sys.environment not implemented for GDScript.";
 	}
 
-	@:runtime public inline static function sleep(seconds: Float): Void {
+	@:runtime public inline static function sleep(seconds:Float):Void {
 		untyped __gdscript__("OS.delay_msec({0} * 1000)", seconds);
 	}
 
-	@:runtime public inline static function setTimeLocale(loc: String): Bool {
+	@:runtime public inline static function setTimeLocale(loc:String):Bool {
 		return false;
 	}
 
-	@:runtime public inline static function getCwd(): String {
+	@:runtime public inline static function getCwd():String {
 		return programPath();
 	}
 
-	@:runtime public inline static function setCwd(s: String): Void {
+	@:runtime public inline static function setCwd(s:String):Void {
 		throw "Sys.setCwd not implemented for GDScript.";
 	}
 
-	@:runtime public inline static function systemName(): String {
+	@:runtime public inline static function systemName():String {
 		return switch untyped __gdscript__("OS.get_name()") {
 			case "macOS": "Mac";
 			case "FreeBSD" | "NetBSD" | "OpenBSD": "BSD";
@@ -50,45 +50,46 @@ extern class Sys {
 		}
 	}
 
-	@:runtime public inline static function command(cmd: String, ?args: Array<String>): Int {
-		if(args == null) args = [];
+	@:runtime public inline static function command(cmd:String, ?args:Array<String>):Int {
+		if (args == null)
+			args = [];
 		return untyped __gdscript__("OS.execute({0}, PackedStringArray({1}))", cmd, args);
 	}
 
-	@:runtime public inline static function exit(code: Int): Void {
+	@:runtime public inline static function exit(code:Int):Void {
 		throw "Sys.exit not implemented for GDScript.";
 	}
 
-	@:runtime public inline static function time(): Float {
+	@:runtime public inline static function time():Float {
 		throw "Sys.time not implemented for GDScript.";
 	}
 
-	@:runtime public inline static function cpuTime(): Float {
+	@:runtime public inline static function cpuTime():Float {
 		return untyped __gdscript__("(Time.get_ticks_msec() * 1000)");
 	}
 
 	@:deprecated("Use programPath instead")
-	@:runtime public inline static function executablePath(): String {
+	@:runtime public inline static function executablePath():String {
 		return programPath();
 	}
 
-	@:runtime public inline static function programPath(): String {
+	@:runtime public inline static function programPath():String {
 		return untyped __gdscript__("OS.get_executable_path()");
 	}
 
-	@:runtime public inline static function getChar(echo: Bool): Int {
+	@:runtime public inline static function getChar(echo:Bool):Int {
 		throw "Sys.getChar not implemented for GDScript.";
 	}
 
-	@:runtime public inline static function stdin(): haxe.io.Input {
+	@:runtime public inline static function stdin():haxe.io.Input {
 		throw "Sys.stdin not implemented for GDScript.";
 	}
 
-	@:runtime public inline static function stdout(): haxe.io.Output {
+	@:runtime public inline static function stdout():haxe.io.Output {
 		throw "Sys.stdout not implemented for GDScript.";
 	}
 
-	@:runtime public inline static function stderr(): haxe.io.Output {
+	@:runtime public inline static function stderr():haxe.io.Output {
 		throw "Sys.stderr not implemented for GDScript.";
 	}
 }


### PR DESCRIPTION
me when hello haii :3


Example:
```hx
package engine;

import gdscript.UntypedArray;

class TestDate extends Node {
	override function _ready() {
		var date = Date.now();
		trace("Date Now: " + date.toString() + " - " + date.getTime() + " - " + date.getFullYear() + "/" + date.getMonth() + "/" + date.getDate() + " "
			+ date.getHours() + ":" + date.getMinutes() + ":" + date.getSeconds());
		var date2 = new Date(2024, 5, 1, 0, 0, 0);
		trace("Date Exactly: " + date2.toString() + " - (expected 2024-06-01 00:00:00)");

		var args:Array<String> = [];
		var r:UntypedArray = cast Sys.args();
		for (i in r) {
			args.push(i);
		}
		trace("Args: " + args.join(", "));
	}
}
```

out:
```py
Godot Engine v4.6.stable.official.89cea1439 - https://godotengine.org
Vulkan 1.4.312 - Forward+ - Using Device #0: NVIDIA - NVIDIA GeForce GTX 1050 Ti

source/engine/TestDate.hx:9: Date Now: 2026-02-09 16:45:55 - 1770655555007.0 - 2026/1/9 16:45:55
source/engine/TestDate.hx:12: Date Exactly: 2024-06-01 00:00:00 - (expected 2024-06-01 00:00:00)
source/engine/TestDate.hx:19: Args: --scene, res://misc/test_date.tscn
--- Debugging process stopped ---
```